### PR TITLE
Integrate save shortcut with manual save

### DIFF
--- a/src/components/editor/editor-body.tsx
+++ b/src/components/editor/editor-body.tsx
@@ -65,6 +65,25 @@ export function EditorBody(props: { initialDocumentId?: string | null; documentI
 
 	// Save lifecycle handled by useEditorDoc
 
+	useEffect(() => {
+		if (props.readOnly) return;
+		if (!editorInstance) return;
+		const handler = async (e: KeyboardEvent): Promise<void> => {
+			const key = e.key || "";
+			if ((key === "s" || key === "S") && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault();
+				try {
+					await (editorInstance as { manualSave?: () => Promise<void> } | null)?.manualSave?.();
+					toast.success("Saved");
+				} catch (err) {
+					toast.error("Save failed");
+				}
+			}
+		};
+		window.addEventListener("keydown", handler as EventListener);
+		return () => window.removeEventListener("keydown", handler as EventListener);
+	}, [editorInstance, props.readOnly]);
+
 	return (
 		<div className="h-[100svh] min-h-screen w-full overflow-hidden flex flex-col">
 			<EditorToolbar


### PR DESCRIPTION
Add `Cmd/Ctrl+S` keyboard shortcut to trigger the existing manual save functionality in the editor.

This provides a convenient keyboard shortcut for the already implemented manual save, without introducing any regressions or refactoring existing editor logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e39fd0e-905c-4476-aecb-39aa42cb9de9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e39fd0e-905c-4476-aecb-39aa42cb9de9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

