### PR TITLE
Update project blocks with conditional display

### DIFF
--- a/src/components/editor/custom-blocks/block-insert-button.tsx
+++ b/src/components/editor/custom-blocks/block-insert-button.tsx
@@ -34,23 +34,27 @@ const blockTypes = [
   },
   {
     id: "datatable",
-    label: "Datatable",
+    label: "Project Tasks",
     icon: <Table size={16} className="text-green-600" />,
     action: (editor: BlockNoteEditor<typeof customSchema.blockSchema, typeof customSchema.inlineContentSchema, typeof customSchema.styleSchema>) => {
+      type EditorWithComments = { options?: { comments?: { threadStore?: { docId?: string } } } };
+      const docId = ((editor as unknown as EditorWithComments).options?.comments?.threadStore?.docId) ?? "";
       insertOrUpdateBlock(editor, {
         type: "datatable",
-        props: { table: "documents" },
+        props: { docId },
       });
     },
   },
   {
     id: "metadata",
-    label: "Metadata",
+    label: "Project Details",
     icon: <FileText size={16} className="text-purple-600" />,
     action: (editor: BlockNoteEditor<typeof customSchema.blockSchema, typeof customSchema.inlineContentSchema, typeof customSchema.styleSchema>) => {
+      type EditorWithComments = { options?: { comments?: { threadStore?: { docId?: string } } } };
+      const docId = ((editor as unknown as EditorWithComments).options?.comments?.threadStore?.docId) ?? "";
       insertOrUpdateBlock(editor, {
         type: "metadata",
-        props: { documentId: "" },
+        props: { docId },
       });
     },
   },

--- a/src/components/editor/custom-blocks/metadata-block.tsx
+++ b/src/components/editor/custom-blocks/metadata-block.tsx
@@ -4,64 +4,83 @@ import { defaultProps } from "@blocknote/core";
 import { useMemo, type ReactElement } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import type { Document } from "@/types/documents.types";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { Id } from "@/convex/_generated/dataModel";
 
 type MetadataProps = {
-  documentId?: string;
+  docId?: string;
   textAlignment?: (typeof defaultProps.textAlignment)["default"];
 };
 
-type BlockProps = { documentId?: string; textAlignment?: (typeof defaultProps.textAlignment)["default"] };
+type BlockProps = { docId?: string; textAlignment?: (typeof defaultProps.textAlignment)["default"] };
 type RenderBlock = { props?: BlockProps };
 type EditorAPI = { updateBlock?: (block: unknown, update: unknown) => void };
 type RenderProps = { block: RenderBlock; editor?: EditorAPI } & Record<string, unknown>;
 
 function MetadataBlockComponent(renderProps: RenderProps): ReactElement {
   const props = (renderProps.block.props as MetadataProps) ?? {};
-  const documents = useQuery(api.documents.list, {}) as Document[] | undefined;
+  const docId = props.docId ?? "";
 
-  const selectedId = props.documentId ?? "";
-  const selected = useMemo(() => {
-    return (documents ?? []).find((d) => String(d._id) === selectedId);
-  }, [documents, selectedId]);
+  const ctx = useQuery(api.documentManagement.getDocumentWithContext as any, docId ? { documentId: docId } : "skip") as
+    | { document: { title: string; createdAt: number; documentType?: string; projectId?: Id<"projects">; clientId?: Id<"clients">; metadata?: any };
+        project: { _id: Id<"projects">; title?: string } | null;
+        client: { _id: Id<"clients">; name?: string } | null;
+        department: { _id: Id<"departments">; name?: string } | null;
+        metadata: any }
+    | null
+    | undefined;
 
-  const handleChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
-    const nextId = e.target.value;
-    try {
-      renderProps.editor?.updateBlock?.(renderProps.block, {
-        type: "metadata",
-        props: { documentId: nextId },
-      });
-    } catch {}
+  const doc = ctx?.document as any;
+  const meta = (ctx?.metadata ?? {}) as any;
+  const project = ctx?.project as any;
+  const client = ctx?.client as any;
+  const department = ctx?.department as any;
+
+  const isProjectBrief = (doc?.documentType) === "project_brief";
+  const hasIds = Boolean(doc?.projectId || meta?.projectId) && Boolean(doc?.clientId || meta?.clientId);
+
+  const getVal = (value: unknown): string => {
+    if (value === undefined || value === null || value === "") return "-";
+    if (typeof value === "number") {
+      // treat large numbers as timestamps
+      if (value > 10_000_000_000) return new Date(value).toLocaleDateString();
+      return String(value);
+    }
+    return String(value);
   };
 
   return (
     <div className="metadata-block" style={{ border: "1px solid var(--meta-border, #e5e7eb)", borderRadius: 8, padding: 12, margin: "8px 0", background: "var(--meta-bg, #fff)" }}>
-      <div className="flex items-center justify-between gap-3" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
-        <div style={{ fontWeight: 600 }}>Document Metadata</div>
-        <div contentEditable={false}>
-          <select value={selectedId} onChange={handleChange} style={{ border: "1px solid var(--meta-border, #e5e7eb)", borderRadius: 6, padding: "4px 8px", background: "var(--meta-select-bg, white)", color: "var(--meta-select-fg, inherit)" }}>
-            <option value="">Select document…</option>
-            {(documents ?? []).map((d) => (
-              <option key={String(d._id)} value={String(d._id)}>{d.title}</option>
-            ))}
-          </select>
-        </div>
-      </div>
-      {selected ? (
-        <div style={{ display: "grid", gridTemplateColumns: "140px 1fr", rowGap: 6, columnGap: 12 }}>
-          <div style={{ color: "var(--meta-muted, #6b7280)" }}>Title</div>
-          <div>{selected.title}</div>
-
-          <div style={{ color: "var(--meta-muted, #6b7280)" }}>Created At</div>
-          <div>{new Date(selected.createdAt).toLocaleString()}</div>
-
-          {selected.ownerId ? <><div style={{ color: "var(--meta-muted, #6b7280)" }}>Owner</div><div>{selected.ownerId}</div></> : null}
-
-          {selected.archivedAt ? <><div style={{ color: "var(--meta-muted, #6b7280)" }}>Archived</div><div>{new Date(selected.archivedAt).toLocaleString()}</div></> : null}
-        </div>
+      <div style={{ fontWeight: 600, marginBottom: 8 }}>Project Details</div>
+      {!isProjectBrief || !hasIds ? (
+        <div className="text-muted-foreground">This block only shows details for project briefs with a project and client.</div>
       ) : (
-        <div style={{ color: "var(--meta-muted, #6b7280)" }}>No document selected.</div>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-56">Field</TableHead>
+              <TableHead>Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell className="font-medium">Client Stakeholders</TableCell>
+              <TableCell>{getVal(client?.name)}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="font-medium">Estimated Time</TableCell>
+              <TableCell>-</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="font-medium">Start Date</TableCell>
+              <TableCell>-</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="font-medium">Due Date</TableCell>
+              <TableCell>-</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
       )}
     </div>
   );
@@ -72,7 +91,7 @@ export const Metadata = createReactBlockSpec(
     type: "metadata",
     propSchema: {
       textAlignment: defaultProps.textAlignment,
-      documentId: { default: "" as const },
+      docId: { default: "" as const },
     },
     content: "none",
   },
@@ -81,10 +100,10 @@ export const Metadata = createReactBlockSpec(
       return <MetadataBlockComponent {...(props as unknown as RenderProps)} />;
     },
     toExternalHTML: (props): ReactElement => {
-      const id = ((props.block.props as MetadataProps)?.documentId ?? "").toString();
+      const id = ((props.block.props as MetadataProps)?.docId ?? "").toString();
       return (
         <div className="metadata-block" data-document-id={id} style={{ border: "1px solid #e5e7eb", borderRadius: 8, padding: 12 }}>
-          <strong>Document Metadata</strong>
+          <strong>Project Details</strong>
         </div>
       );
     },

--- a/src/components/editor/custom-blocks/slash-menu-items.tsx
+++ b/src/components/editor/custom-blocks/slash-menu-items.tsx
@@ -33,34 +33,38 @@ export const getCustomSlashMenuItems = (
     subtext: "Insert an alert message block",
   },
 
-  // Datatable block
+  // Project Tasks block
   {
-    title: "Datatable",
+    title: "Project Tasks",
     onItemClick: () => {
+      type EditorWithComments = { options?: { comments?: { threadStore?: { docId?: string } } } };
+      const docId = ((editor as unknown as EditorWithComments).options?.comments?.threadStore?.docId) ?? "";
       insertOrUpdateBlock(editor, {
         type: "datatable",
-        props: { table: "documents" },
+        props: { docId },
       });
     },
-    aliases: ["datatable", "table", "documents"],
+    aliases: ["datatable", "table", "tasks", "project tasks"],
     group: "Custom Blocks",
     icon: <Table size={18} className="text-green-600" />,
-    subtext: "Insert a dynamic documents table",
+    subtext: "Insert a table of tasks for this project",
   },
 
-  // Metadata block
+  // Project Details block
   {
-    title: "Metadata",
+    title: "Project Details",
     onItemClick: () => {
+      type EditorWithComments = { options?: { comments?: { threadStore?: { docId?: string } } } };
+      const docId = ((editor as unknown as EditorWithComments).options?.comments?.threadStore?.docId) ?? "";
       insertOrUpdateBlock(editor, {
         type: "metadata",
-        props: { documentId: "" },
+        props: { docId },
       });
     },
-    aliases: ["metadata", "meta", "document info"],
+    aliases: ["metadata", "project details", "details"],
     group: "Custom Blocks",
     icon: <FileText size={18} className="text-purple-600" />,
-    subtext: "Insert a document metadata card",
+    subtext: "Insert a project details table",
   },
 
   // Weekly Update block


### PR DESCRIPTION
Refactor `datatable` and `metadata` custom blocks into 'Project Tasks' and 'Project Details' to display project-specific information and tasks, gated by document type and project/client IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-730d8ee0-6af1-4a8c-b475-c135ac9ef220">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-730d8ee0-6af1-4a8c-b475-c135ac9ef220">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

