### PR TITLE
Add comment indicator to sidebar nav

### DIFF
--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -126,6 +126,27 @@ export const listByTask = query({
   },
 });
 
+// Returns a mapping of docId -> unresolved thread count
+export const getUnresolvedCountsByDoc = query({
+  args: { docIds: v.array(v.string()) },
+  handler: async (ctx, { docIds }) => {
+    const result: Record<string, number> = {};
+    for (const id of docIds) {
+      try {
+        const threads = await ctx.db
+          .query("commentThreads")
+          .withIndex("by_doc", (q) => q.eq("docId", id))
+          .collect();
+        const unresolved = threads.filter((t) => !t.resolved).length;
+        result[id] = unresolved;
+      } catch {
+        result[id] = 0;
+      }
+    }
+    return result;
+  },
+});
+
 export const listByThread = query({
   args: { threadId: v.string() },
   handler: async (ctx, { threadId }) => {

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -9,6 +9,7 @@
 
 ### Recently Completed (UI Enhancement)
 - Editor: For `project_brief` documents with a `clientId`, the editor top bar now shows the client logo to the left of the document title, followed by a subtle divider and the client name in muted gray. If no `clientId` is present, the title appears as before. Implemented in `src/components/editor/editor-top-bar.tsx` using `clients.getClientById` and `clients.getLogoUrl`.
+ - Pages Sidebar: Added subtle comment indicator on page items when there are unresolved comments for that page. Uses `comments.getUnresolvedCountsByDoc` and renders a small message icon on the right of the link in `src/components/editor/sidebar/page-sidebar.tsx`.
 
 ### Recently Completed (Editor Cleanup)
 - Removed legacy/current editor UI and route integration; added placeholder at `src/app/editor/[documentId]/page.tsx`


### PR DESCRIPTION
Add a subtle comment icon to page sidebar nav items to indicate pages with unresolved comments.

---
<a href="https://cursor.com/background-agent?bcId=bc-78ca9e46-a08e-4336-b7d9-5db9baa352a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78ca9e46-a08e-4336-b7d9-5db9baa352a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

