### PR TITLE
Replace browser alerts with shadcn dialogs

### DIFF
--- a/src/components/editor/editor-body.tsx
+++ b/src/components/editor/editor-body.tsx
@@ -13,6 +13,9 @@ import { EditorSidebar } from "@/components/editor/editor-sidebar";
 import { EditorCanvas } from "@/components/editor/editor-canvas";
 import { useEditorDoc } from "@/hooks/editor/use-editor-doc";
 import { useEditorPresence } from "@/hooks/editor/use-editor-presence";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 export function EditorBody(props: { initialDocumentId?: string | null; documentId?: string | null; readOnly?: boolean; hideControls?: { back?: boolean; insert?: boolean; comments?: boolean; options?: boolean; presence?: boolean; share?: boolean } }): ReactElement {
 	const [documentId] = useState<string | null>(props.initialDocumentId ?? props.documentId ?? null);
@@ -33,11 +36,22 @@ export function EditorBody(props: { initialDocumentId?: string | null; documentI
 	const createThreadMutation = useMutation(api.comments.createThread);
 	const renamePageMutation = useMutation(api.pages.rename);
 
+	// Create Page dialog state
+	const [createOpen, setCreateOpen] = useState<boolean>(false);
+	const [createTitle, setCreateTitle] = useState<string>("Untitled");
+
 	const onCreatePage = async (): Promise<void> => {
 		if (!documentId) return;
-		const title = prompt("New page title", "Untitled") || "Untitled";
+		setCreateTitle("Untitled");
+		setCreateOpen(true);
+	};
+
+	const handleConfirmCreate = async (): Promise<void> => {
+		if (!documentId) return;
+		const title = createTitle?.trim() || "Untitled";
 		const { docId } = await createPage({ documentId: documentId as unknown as Id<"documents">, title });
 		setPageDocId(docId);
+		setCreateOpen(false);
 	};
 
 	const { pages } = usePages(documentId as unknown as Id<"documents"> | null);
@@ -218,6 +232,20 @@ export function EditorBody(props: { initialDocumentId?: string | null; documentI
 				theme={theme}
 				onChangeTheme={setTheme}
 			/>
+
+			{/* Create Page Dialog */}
+			<Dialog open={createOpen} onOpenChange={(open) => { if (!open) setCreateOpen(false); }}>
+				<DialogContent className="sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>New page</DialogTitle>
+					</DialogHeader>
+					<Input autoFocus value={createTitle} onChange={(e) => setCreateTitle(e.target.value)} placeholder="Untitled" />
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+						<Button onClick={handleConfirmCreate}>Create</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/src/components/editor/sidebar/page-sidebar.tsx
+++ b/src/components/editor/sidebar/page-sidebar.tsx
@@ -4,6 +4,10 @@ import { ChevronDown, ChevronRight, PanelLeftClose, Plus } from "lucide-react";
 import { usePages } from "@/hooks";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { Page } from "@/types/pages.types";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 interface PageSidebarProps {
 	documentId: string | null;
@@ -18,6 +22,12 @@ export function PageSidebar(props: PageSidebarProps): ReactElement {
 	const { topLevelPages, childrenByParent, operations } = usePages(props.documentId as unknown as Id<"documents"> | null);
 	const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 	const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+	// Dialog states
+	const [renameState, setRenameState] = useState<{ pageId: Id<"documentPages">; currentTitle: string } | null>(null);
+	const [renameTitle, setRenameTitle] = useState<string>("");
+	const [subpageState, setSubpageState] = useState<{ parentId: Id<"documentPages">; parentTitle: string } | null>(null);
+	const [subpageTitle, setSubpageTitle] = useState<string>("Untitled page");
+	const [deleteState, setDeleteState] = useState<{ page: Page } | null>(null);
 	const isDark = props.theme === "dark";
 	const containerClass = [
 		"w-64 h-full border-r p-2 transition-transform duration-300 ease-in-out",
@@ -60,8 +70,8 @@ export function PageSidebar(props: PageSidebarProps): ReactElement {
 								{openMenuId === String(p._id) ? (
 									<div className={menuSurface}>
 										<button className={menuItem} onClick={async () => {
-											const title = prompt("Rename page", p.title) || p.title;
-											await operations.renamePage(p._id, title);
+											setRenameState({ pageId: p._id, currentTitle: p.title });
+											setRenameTitle(p.title);
 											setOpenMenuId(null);
 										}}>Rename</button>
 										{idx > 0 ? (
@@ -82,17 +92,12 @@ export function PageSidebar(props: PageSidebarProps): ReactElement {
 											}}>Move Down</button>
 										) : null}
 										<button className={menuItem} onClick={async () => {
-											const title = prompt("New subpage title", "Untitled page") || "Untitled page";
-											const res = await operations.createSubpage(p._id, title);
-											setExpanded((prev) => ({ ...prev, [String(p._id)]: true }));
-											props.onSelect(res.docId);
+											setSubpageState({ parentId: p._id, parentTitle: p.title });
+											setSubpageTitle("Untitled page");
 											setOpenMenuId(null);
 										}}>Add subpage</button>
 										<button className={dangerItem} onClick={async () => {
-											if (confirm("Delete page?")) {
-												await operations.removePage(p._id);
-												if (props.activePageDocId === p.docId) props.onSelect("");
-											}
+											setDeleteState({ page: p });
 											setOpenMenuId(null);
 										}}>Delete Page</button>
 									</div>
@@ -114,8 +119,8 @@ export function PageSidebar(props: PageSidebarProps): ReactElement {
 											{openMenuId === String(c._id) ? (
 												<div className={menuSurface}>
 													<button className={menuItem} onClick={async () => {
-														const title = prompt("Rename page", c.title) || c.title;
-														await operations.renamePage(c._id, title);
+														setRenameState({ pageId: c._id, currentTitle: c.title });
+														setRenameTitle(c.title);
 														setOpenMenuId(null);
 													}}>Rename</button>
 													{cIdx > 0 ? (
@@ -136,10 +141,7 @@ export function PageSidebar(props: PageSidebarProps): ReactElement {
 														}}>Move Down</button>
 													) : null}
 													<button className={dangerItem} onClick={async () => {
-														if (confirm("Delete page?")) {
-															await operations.removePage(c._id);
-															if (props.activePageDocId === c.docId) props.onSelect("");
-														}
+														setDeleteState({ page: c });
 														setOpenMenuId(null);
 													}}>Delete Page</button>
 												</div>
@@ -154,6 +156,65 @@ export function PageSidebar(props: PageSidebarProps): ReactElement {
 			})}
 			</div>
 			<button className={["mt-2 flex w-full items-center gap-1 px-2 py-1 text-left text-sm", isDark ? "text-neutral-300 hover:text-white" : "text-neutral-600 hover:text-neutral-900"].join(" ")} onClick={props.onCreatePage} disabled={!props.documentId}><Plus className="h-4 w-4" /> New page</button>
+
+			{/* Rename Dialog */}
+			<Dialog open={!!renameState} onOpenChange={(open) => { if (!open) setRenameState(null); }}>
+				<DialogContent className="sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>Rename page</DialogTitle>
+					</DialogHeader>
+					<Input autoFocus value={renameTitle} onChange={(e) => setRenameTitle(e.target.value)} placeholder="Untitled" />
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setRenameState(null)}>Cancel</Button>
+						<Button onClick={async () => {
+							if (!renameState) return;
+							await operations.renamePage(renameState.pageId, renameTitle || "Untitled");
+							setRenameState(null);
+						}}>Save</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* New Subpage Dialog */}
+			<Dialog open={!!subpageState} onOpenChange={(open) => { if (!open) setSubpageState(null); }}>
+				<DialogContent className="sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>New subpage</DialogTitle>
+					</DialogHeader>
+					<Input value={subpageTitle} onChange={(e) => setSubpageTitle(e.target.value)} placeholder="Untitled page" />
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setSubpageState(null)}>Cancel</Button>
+						<Button onClick={async () => {
+							if (!subpageState) return;
+							const res = await operations.createSubpage(subpageState.parentId, subpageTitle || "Untitled page");
+							setExpanded((prev) => ({ ...prev, [String(subpageState.parentId)]: true }));
+							props.onSelect(res.docId);
+							setSubpageState(null);
+						}}>Create</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Delete Page Confirm */}
+			<AlertDialog open={!!deleteState} onOpenChange={(open) => { if (!open) setDeleteState(null); }}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete page?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone. The page "{deleteState?.page.title}" will be permanently deleted.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel onClick={() => setDeleteState(null)}>Cancel</AlertDialogCancel>
+						<AlertDialogAction onClick={async () => {
+							if (!deleteState) return;
+							await operations.removePage(deleteState.page._id);
+							if (props.activePageDocId === deleteState.page.docId) props.onSelect("");
+							setDeleteState(null);
+						}}>Delete</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }


### PR DESCRIPTION
Replace all browser alert dialogs in the editor with shadcn dialog components to ensure consistent UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d3aeeb0-1667-4ca3-acb3-1b2bd99b75e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d3aeeb0-1667-4ca3-acb3-1b2bd99b75e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

